### PR TITLE
Add a module with a read-only std::env-style interface that reads from apple args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,12 @@ license = "Apache-2.0 OR MIT"
 repository = "https://github.com/BlackHoleFox/appleargs"
 description = "Obtain the current process' apple arguments"
 keywords = ["apple", "darwin", "macos", "args", "applep"]
-categories = ["os::macos-apis"] 
+categories = ["os::macos-apis"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[features]
+empty-on-unsupported = []
 
 [dependencies]
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A smol crate to grab your process' "apple arguments"
 
 ## What are apple arguments?
 
-They are an extra set of strings optionally passed to an executable by the kernel on Darwin-based operating systems. They are entirely undocumented (Open an issue if you find it :D), and as far as anyone can tell, solely intended to store or hint precomputed information about the running process for `dyld` to use. 
+They are an extra set of strings optionally passed to an executable by the kernel on Darwin-based operating systems. They are entirely undocumented (Open an issue if you find it :D), and as far as anyone can tell, solely intended to store or hint precomputed information about the running process for `dyld` to use.
 
 The values are set during the [exec sequence] of a process and subsequently read by `dyld` at various points when it starts an executable. While these can easily change, `dyld` is open source so it can be referenced for good examples like...
 
@@ -33,11 +33,15 @@ The values are set during the [exec sequence] of a process and subsequently read
 ```
 
 ## Supported Operating Systems
-This crate should on most macOS and iOS versions (but is not explictly tested). Automated testing occurs on:
+This crate should work on most macOS, iOS, and tvOS versions (but is not explictly tested). Automated testing occurs on:
 - macOS 10.15
 - macOS 11
 - macOS 12
 - iOS 12.4
+
+On unsupported platforms we will emit a compiler error by default.
+
+If this is undesirable (for example, if you need to handle "missing arg" and "wrong os" equivalently, or if you do not want to try and match our set of supported platforms), `features = ["empty-on-unsupported"]` may be enabled, which allows us to support the full API by pretending we received an empty array of apple arguments on other targets.
 
 [exec sequence]: https://github.com/apple-oss-distributions/xnu/blob/e7776783b89a353188416a9a346c6cdb4928faad/bsd/kern/kern_exec.c#L5508
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,0 +1,12 @@
+fn main() {
+    let args = appleargs::apple_args();
+    let argc = args.len();
+    if argc == 0 {
+        println!("No apple arguments found (unsupported target?)");
+        return;
+    }
+    println!("{} apple arguments given to this process:", args.len());
+    for (i, entry) in args.enumerate() {
+        println!("[{i}]: {entry:?}");
+    }
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,225 @@
+//! Inspection of the "apple" arguments as if it were another set of environment
+//! variables.
+//!
+//! While the format of the apple arguments is not documented and may be
+//! unstable at the moment it is generally identical to the syntax used by
+//! strings in the environment[^1]. This seems deliberate, as the apple
+//! arguments are passed into the process in a similar manner to `envp` as well.
+//!
+//! This module provides an interface similar to the environment-reading (but
+//! not writing) functions in [`std::env`], but which use the apple arguments
+//! instead.
+//!
+//! The used for the apple arguments may be unstable, so the functions in this
+//! module ignore arguments which cannot be parsed as an environment variable
+//! (that is, ones which do not contain the `'='` character), rather than
+//! producing an error or even panicking.
+//!
+//! In the future, if the apple arguments change to include strings which do not
+//! conform to the environment variable syntax, this module will continue
+//! working. If this happens, you can access the "complete" argument set using
+//! iterator functions in the crate root, such as [`appleargs::apple_args_os`].
+//!
+//! [^1]: that is, `"$key=$value"` where `$key` does not contain the `'='`
+//!     character, and neither `$key` nor `$value` contain `'\0'`.
+
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt as _;
+
+/// An iterator over the "apple" arguments parsed into UTF-8 "env var"-style
+/// key/value pairs.
+///
+/// This type is most similar to [`std::env::Vars`], but uses the pseudo-env
+/// made up of the apple arguments, rather than the "real" environment.
+///
+/// This struct is returned by [`appleargs::env::apple_vars()`](apple_vars), see
+/// it and the [module documentation](crate::env) for more information.
+#[derive(Clone)]
+#[must_use]
+pub struct AppleVars {
+    inner: SplitArgsIter,
+}
+
+/// An iterator over the "apple" arguments parsed as "env var"-style key/value
+/// pairs.
+///
+/// This type is most similar to [`std::env::VarsOs`], but uses the pseudo-env
+/// made up of the apple arguments, rather than the "real" environment.
+///
+/// This struct is returned by [`env::apple_vars_os()`](apple_vars_os), see it
+/// and the [module documentation](crate::env) for more information.
+#[derive(Clone)]
+#[must_use]
+pub struct AppleVarsOs {
+    inner: SplitArgsIter,
+}
+
+/// Returns an iterator over the key/value pairs in the pseudo-environment
+/// provided as apple arguments.
+///
+/// This is a tuple of `(&str, &str)`. Currently we panic if we encounter
+/// invalid UTF-8 is encountered. You should use [`apple_vars_os`] if this is
+/// undesirable.
+#[inline]
+pub fn apple_vars() -> AppleVars {
+    AppleVars {
+        inner: split_args_iter(),
+    }
+}
+
+/// Returns an iterator over the key/value pairs in the pseudo-environment
+/// provided as apple arguments.
+///
+/// It is essentially equivalent to [`std::env::vars_os`], but uses apple
+/// arguments rather than the process environment.
+///
+/// This is a tuple of `(&OsStr, &OsStr)`. These are not guaranteed to be UTF-8.
+/// If this is undesirable, you should use the [`apple_vars()`] function instead.
+#[inline]
+pub fn apple_vars_os() -> AppleVarsOs {
+    AppleVarsOs {
+        inner: split_args_iter(),
+    }
+}
+
+impl Iterator for AppleVarsOs {
+    type Item = (&'static OsStr, &'static OsStr);
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|(k, v)| (OsStr::from_bytes(k), OsStr::from_bytes(v)))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+    // Can't provide more efficient impl of anything else. (Note that our inner
+    // iterator is not an `ExactSizeIterator`)
+}
+
+impl DoubleEndedIterator for AppleVarsOs {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(|(k, v)| (OsStr::from_bytes(k), OsStr::from_bytes(v)))
+    }
+}
+
+impl core::iter::FusedIterator for AppleVarsOs {}
+
+impl core::fmt::Debug for AppleVarsOs {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
+impl Iterator for AppleVars {
+    type Item = (&'static str, &'static str);
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next()
+            .map(|(k, v)| (super::str_from_slice(&k), super::str_from_slice(&v)))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+    // Can't provide more efficient impl of anything else. (Note that our inner
+    // iterator is not an `ExactSizeIterator`)
+}
+
+impl DoubleEndedIterator for AppleVars {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner
+            .next_back()
+            .map(|(k, v)| (super::str_from_slice(&k), super::str_from_slice(&v)))
+    }
+}
+
+impl core::iter::FusedIterator for AppleVars {}
+
+impl core::fmt::Debug for AppleVars {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
+type SplitArgsIter = core::iter::FilterMap<
+    core::iter::Copied<core::slice::Iter<'static, &'static [u8]>>,
+    fn(&[u8]) -> Option<(&[u8], &[u8])>,
+>;
+
+#[inline]
+fn split_args_iter() -> SplitArgsIter {
+    super::args_slice().iter().copied().filter_map(split_kv)
+}
+
+#[inline]
+fn split_kv<'a>(s: &'a [u8]) -> Option<(&'a [u8], &'a [u8])> {
+    debug_assert!(!s.contains(&b'\0'));
+    let equals = s.iter().position(|&b| b == b'=')?;
+    Some((&s[..equals], &s[(equals + 1)..]))
+}
+
+/// Searches the apple argument pseudo-env for a variable with the name `s`, and
+/// returns it, if one is found.
+///
+/// It is analogous to [`std::env::var`], but treats the apple arguments as
+/// an environment, rather than using the "real" environment.
+///
+/// This method returns an error if the value of the variable is not valid
+/// UTF-8. See [`apple_var_os`] for a similar function without this requirement.
+pub fn apple_var(s: impl AsRef<[u8]>) -> Result<&'static str, VarError> {
+    fn apple_var_impl(s: &[u8]) -> Result<&'static str, VarError> {
+        if let Some((_, v)) = split_args_iter().find(|&(k, _)| k == s) {
+            core::str::from_utf8(v).map_err(|_| VarError::NotUnicode(v))
+        } else {
+            Err(VarError::NotPresent)
+        }
+    }
+    apple_var_impl(s.as_ref())
+}
+
+/// Searches the apple argument pseudo-env for a variable with the name `s`, and
+/// returns it, if one is found.
+///
+/// It is analogous to [`std::env::var_os`], but treats the apple arguments as
+/// an environment, rather than using the "real" environment.
+///
+/// This method returns an [`OsStr`], which may not be valid UTF-8. If this is
+/// undesirable, see [`apple_var_os`], which returns an error if the value is
+/// not valid UTF-8.
+pub fn apple_var_os(s: impl AsRef<OsStr>) -> Option<&'static OsStr> {
+    fn apple_var_os_impl(s: &OsStr) -> Option<&'static OsStr> {
+        split_args_iter()
+            .find(|&(k, _)| k == s.as_bytes())
+            .map(|(_, v)| OsStr::from_bytes(v))
+    }
+    apple_var_os_impl(s.as_ref())
+}
+
+/// The error type returned by [`appleargs::env::apple_var`](apple_var).
+///
+/// Essentially equivalent to [`std::env::VarError`], but uses a static
+/// reference (and not a `Vec`) in the `NotUnicode` variant, as we operate on a
+/// static copy of the apple arguments.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum VarError {
+    /// The specified environment variable was not present.
+    NotPresent,
+    /// The specified environment variable was found, but was not valid UTF-8.
+    NotUnicode(&'static [u8]),
+}
+
+// #[cfg(test)]
+// mod test {
+//     static FAKE_ARGS = &[];
+//     #[test]
+//     fn fake_apple_args()
+// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,17 +2,40 @@
 #![deny(missing_docs, clippy::undocumented_unsafe_blocks)]
 
 use core::iter::FusedIterator;
-use core::ptr::{self, NonNull};
-use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use std::ffi::OsStr;
-use std::os::raw::{c_char, c_int};
 use std::os::unix::prelude::OsStrExt;
 
 pub mod env;
 
-// todo: (target_os = "tvos", target_os = "watchos") after testing
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
-compile_error!("appleargs is not supported on this platform");
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+))]
+mod sys;
+
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+)))]
+mod sys {
+    #[inline]
+    #[cfg(feature = "empty-on-unsupported")]
+    pub(super) fn args_slice() -> &'static [&'static [u8]] {
+        &[]
+    }
+    #[cfg(not(feature = "empty-on-unsupported"))]
+    compile_error!(
+        "The `appleargs` crate is unsupported on this target, \
+        and the `\"empty-on-unsupported\"` cargo feature has \
+        not been enabled."
+    );
+}
+
+use sys::args_slice;
 
 /// An iterator over the process' apple arguments.
 ///
@@ -144,99 +167,6 @@ pub fn apple_args_os() -> AppleArgsOs {
 fn str_from_slice<'a>(bytes: &&'a [u8]) -> &'a str {
     core::str::from_utf8(bytes).expect("apple argument was not valid UTF-8")
 }
-
-fn args_slice() -> &'static [&'static [u8]] {
-    // This synchronizes with the `Release` store and acts as a fence.
-    let data = ARGS_DATA.load(Ordering::Acquire);
-
-    NonNull::new(data)
-        .map(|ptr| {
-            // `Relaxed` is fine because it is fenced by the `Acquire` used
-            // for `data` and `len` is written prior to storing `data`.
-            let len = ARGS_LEN.load(Ordering::Relaxed);
-            // Safety: `ptr` is always a valid slice and `len` always matches
-            // because of the orderings.
-            unsafe { core::slice::from_raw_parts(ptr.as_ptr(), len) }
-        })
-        .unwrap_or(&[])
-}
-
-static ARGS_DATA: AtomicPtr<&'static [u8]> = AtomicPtr::new(ptr::null_mut());
-static ARGS_LEN: AtomicUsize = AtomicUsize::new(0);
-
-unsafe extern "C" fn init_function(
-    _argc: c_int,
-    _argv: *const *const c_char,
-    _envp: *const *const c_char,
-    mut applep: *const *const c_char,
-) {
-    // Set up an abort guard. It's likely to be extremely bad for us to panic
-    // inside a `__mod_init_func`, even more than unwinding across C code
-    // normally would be. Eventually rustc will set an abort guard up for us in
-    // `extern "C" fn`, but for now it doesn't, so we do it manually.
-    let panic_in_static_ctor_sounds_bad = AbortGuard;
-    let mut v: Vec<&'static [u8]> = Vec::new();
-
-    // Safety: `applep` is not null, so its valid to read another pointer from.
-    while !applep.is_null() && !applep.read().is_null() {
-        // Safety: See above
-        let p: *const c_char = applep.read();
-
-        // Safety: `applep` was pointing at a valid nul-terminated
-        // string.
-        let len = strlen(p);
-        let ptr = p as *const u8;
-        let s = core::slice::from_raw_parts(ptr, len); // Explicit nul skip.
-
-        if !s.is_empty() {
-            v.push(Box::leak(s.into()));
-        }
-
-        // Safety: This will never wrap and after incrementing
-        // past the last array element, the loop will stop.
-        applep = applep.add(1);
-    }
-
-    let vslice = v.leak::<'static>();
-    // `Relaxed` is fine because the store of `data` with
-    // `Release` acts as a fence, and `len` is always loaded
-    // after `data`.
-    ARGS_LEN.store(vslice.len(), Ordering::Relaxed);
-    ARGS_DATA.store(vslice.as_mut_ptr(), Ordering::Release);
-    // Disarm the abort guard.
-    core::mem::forget(panic_in_static_ctor_sounds_bad);
-}
-
-extern "C" {
-    /// Provided by libc or compiler_builtins.
-    fn strlen(s: *const c_char) -> usize;
-}
-
-struct AbortGuard;
-impl Drop for AbortGuard {
-    #[cold]
-    #[inline(never)]
-    fn drop(&mut self) {
-        // It would be better to use the real `abort`, but the only way for this
-        // struct to have `Drop` run is if the dtor is run during unwinding of
-        // some other panic, which means this will be a double panic (which
-        // aborts). That said, this should ever happen unless an allocator
-        // panics (and they shouldn't), so whatever.
-        panic!("Triggering abort via double-panic");
-    }
-}
-
-#[used]
-#[cfg_attr(
-    any(target_os = "macos", target_os = "ios"),
-    link_section = "__DATA,__mod_init_func"
-)]
-static CTOR: unsafe extern "C" fn(
-    argc: c_int,
-    argv: *const *const c_char,
-    envp: *const *const c_char,
-    applep: *const *const c_char,
-) = init_function;
 
 #[cfg(test)]
 mod tests {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,0 +1,96 @@
+use core::ptr::{self, NonNull};
+use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
+use std::os::raw::{c_char, c_int};
+
+pub fn args_slice() -> &'static [&'static [u8]] {
+    // This synchronizes with the `Release` store and acts as a fence.
+    let data = ARGS_DATA.load(Ordering::Acquire);
+
+    NonNull::new(data)
+        .map(|ptr| {
+            // `Relaxed` is fine because it is fenced by the `Acquire` used
+            // for `data` and `len` is written prior to storing `data`.
+            let len = ARGS_LEN.load(Ordering::Relaxed);
+            // Safety: `ptr` is always a valid slice and `len` always matches
+            // because of the orderings.
+            unsafe { core::slice::from_raw_parts(ptr.as_ptr(), len) }
+        })
+        .unwrap_or(&[])
+}
+
+static ARGS_DATA: AtomicPtr<&'static [u8]> = AtomicPtr::new(ptr::null_mut());
+static ARGS_LEN: AtomicUsize = AtomicUsize::new(0);
+
+unsafe extern "C" fn init_function(
+    _argc: c_int,
+    _argv: *const *const c_char,
+    _envp: *const *const c_char,
+    mut applep: *const *const c_char,
+) {
+    // Set up an abort guard. It's likely to be extremely bad for us to panic
+    // inside a `__mod_init_func`, even more than unwinding across C code
+    // normally would be. Eventually rustc will set an abort guard up for us in
+    // `extern "C" fn`, but for now it doesn't, so we do it manually.
+    let panic_in_static_ctor_sounds_bad = AbortGuard;
+    let mut v: Vec<&'static [u8]> = Vec::new();
+
+    // Safety: `applep` is not null, so its valid to read another pointer from.
+    while !applep.is_null() && !applep.read().is_null() {
+        // Safety: See above
+        let p: *const c_char = applep.read();
+
+        // Safety: `applep` was pointing at a valid nul-terminated
+        // string.
+        let len = strlen(p);
+        let ptr = p as *const u8;
+        let s = core::slice::from_raw_parts(ptr, len); // Explicit nul skip.
+
+        if !s.is_empty() {
+            v.push(Box::leak(s.into()));
+        }
+
+        // Safety: This will never wrap and after incrementing
+        // past the last array element, the loop will stop.
+        applep = applep.add(1);
+    }
+
+    let vslice = v.leak::<'static>();
+    // `Relaxed` is fine because the store of `data` with
+    // `Release` acts as a fence, and `len` is always loaded
+    // after `data`.
+    ARGS_LEN.store(vslice.len(), Ordering::Relaxed);
+    ARGS_DATA.store(vslice.as_mut_ptr(), Ordering::Release);
+    // Disarm the abort guard.
+    core::mem::forget(panic_in_static_ctor_sounds_bad);
+}
+
+extern "C" {
+    /// Provided by libc or compiler_builtins.
+    fn strlen(s: *const c_char) -> usize;
+}
+
+struct AbortGuard;
+impl Drop for AbortGuard {
+    #[cold]
+    #[inline(never)]
+    fn drop(&mut self) {
+        // It would be better to use the real `abort`, but the only way for this
+        // struct to have `Drop` run is if the dtor is run during unwinding of
+        // some other panic, which means this will be a double panic (which
+        // aborts). That said, this should ever happen unless an allocator
+        // panics (and they shouldn't), so whatever.
+        panic!("Triggering abort via double-panic");
+    }
+}
+
+#[used]
+#[cfg_attr(
+    any(target_os = "macos", target_os = "ios"),
+    link_section = "__DATA,__mod_init_func"
+)]
+static CTOR: unsafe extern "C" fn(
+    argc: c_int,
+    argv: *const *const c_char,
+    envp: *const *const c_char,
+    applep: *const *const c_char,
+) = init_function;


### PR DESCRIPTION
Needs tests and docs I guess. Also has other stuff too -- mostly because I had intended to make most of these functions more testable by allowing them to be passed a `&'static [&'static [u8]]`. As a result, it's a slightly larger patch than is needed.

Not sure when I'll finish this so feel free to take and do with it what you like (even if that's "discard it").